### PR TITLE
silence compiler warnings about narrowing, unused formal parameters, …

### DIFF
--- a/test/mp_with_index.cpp
+++ b/test/mp_with_index.cpp
@@ -20,9 +20,9 @@ using boost::mp11::mp_iota_c;
 
 struct F
 {
-    int i_;
+    std::size_t i_;
 
-    explicit F( int i ): i_( i ) {}
+    explicit F( std::size_t i ): i_( i ) {}
 
     template<std::size_t I> bool operator()( mp_size_t<I> ) const
     {


### PR DESCRIPTION
…and unsafe use of 'bool'.
Seen with msvc /W4.

Signed-off-by: Daniela Engert <dani@ngrt.de>