### PR TITLE
Adds mp_eval_and

### DIFF
--- a/include/boost/mp11/function.hpp
+++ b/include/boost/mp11/function.hpp
@@ -218,24 +218,24 @@ template<class T1, class... T> using mp_max = mp_max_element<mp_list<T1, T...>, 
 namespace detail
 {
 
-template<class T, class... F> struct mp_eval_and_impl;
+template<class T, template<class>class... F> struct mp_eval_and_impl;
 
 } // namespace detail
 
 // mp_eval_and<T, F...>
-template<class T, class... F> using mp_eval_and = typename detail::mp_eval_and_impl<T, F...>::type;
+template<class T, template<class>class... F> using mp_eval_and = typename detail::mp_eval_and_impl<T, F...>::type;
 
 namespace detail
 {
 
-template<class T, class... F> struct mp_eval_and_impl;
+template<class T, template<class> class... F> struct mp_eval_and_impl;
 
 template<class T> struct mp_eval_and_impl<T>
 {
     using type = mp_true;
 };
 
-template<class T, class F1, class... F> struct mp_eval_and_impl<T, F1, F...>
+template<class T, template<class>class F1, template<class>class... F> struct mp_eval_and_impl<T, F1, F...>
 {
     using type = mp_and<mp_eval_or<mp_false, F1, T>, mp_eval_and<T, F...>>;
 };

--- a/include/boost/mp11/function.hpp
+++ b/include/boost/mp11/function.hpp
@@ -215,6 +215,33 @@ template<class T1, class... T> using mp_min = mp_min_element<mp_list<T1, T...>, 
 // mp_max<T...>
 template<class T1, class... T> using mp_max = mp_max_element<mp_list<T1, T...>, mp_less>;
 
+namespace detail
+{
+
+template<class T, class... F> struct mp_eval_and_impl;
+
+} // namespace detail
+
+// mp_eval_and<T, F...>
+template<class T, class... F> using mp_eval_and = typename detail::mp_eval_and_impl<T, F...>::type;
+
+namespace detail
+{
+
+template<class T, class... F> struct mp_eval_and_impl;
+
+template<class T> struct mp_eval_and_impl<T>
+{
+    using type = mp_true;
+};
+
+template<class T, class F1, class... F> struct mp_eval_and_impl<T, F1, F...>
+{
+    using type = mp_and<mp_eval_or<mp_false, F1, T>, mp_eval_and<T, F...>>;
+};
+
+} // namespace detail
+
 } // namespace mp11
 } // namespace boost
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -171,6 +171,7 @@ run mp_less.cpp ;
 run mp_min.cpp ;
 run mp_max.cpp ;
 run mp_similar.cpp ;
+run mp_eval_and.cpp ;
 
 # map
 run mp_map_find.cpp ;

--- a/test/mp_eval_and.cpp
+++ b/test/mp_eval_and.cpp
@@ -1,0 +1,27 @@
+
+// Copyright 2019 Hans Dembinski.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+
+#include <boost/mp11/function.hpp>
+#include <boost/mp11/integral.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+#include <type_traits>
+
+int main()
+{
+    using boost::mp11::mp_eval_and;
+
+    BOOST_TEST_TRAIT_TRUE((mp_eval_and<char>));
+
+    BOOST_TEST_TRAIT_TRUE((mp_eval_and<int, std::is_integral, std::is_signed>));
+    BOOST_TEST_TRAIT_FALSE((mp_eval_and<unsigned, std::is_integral, std::is_signed>));
+    BOOST_TEST_TRAIT_FALSE((mp_eval_and<float, std::is_integral, std::is_signed>));
+    BOOST_TEST_TRAIT_FALSE((mp_eval_and<char[], std::is_integral, std::is_unsigned>));
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
See #33. I think this is a useful primitive to have in the library. Perhaps the implementation can be optimized and the test code needs a better test case, as pointed out in the issue.