### PR TITLE
Fix GCC sign conversion warning

### DIFF
--- a/include/boost/mp11/detail/mp_count.hpp
+++ b/include/boost/mp11/detail/mp_count.hpp
@@ -39,13 +39,13 @@ constexpr std::size_t cx_plus()
 
 template<class T1, class... T> constexpr std::size_t cx_plus(T1 t1, T... t)
 {
-    return t1 + cx_plus(t...);
+    return static_cast<std::size_t>(t1) + cx_plus(t...);
 }
 
 template<class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class... T>
 constexpr std::size_t cx_plus(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T... t)
 {
-    return t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8 + t9 + t10 + cx_plus(t...);
+    return static_cast<std::size_t>(t1 + t2 + t3 + t4 + t5 + t6 + t7 + t8 + t9 + t10) + cx_plus(t...);
 }
 
 template<template<class...> class L, class... T, class V> struct mp_count_impl<L<T...>, V>


### PR DESCRIPTION
The conversion bool -> int -> std::size_t triggers GCC sign conversion warning.

I don't know your policy about those warnings. Alternatively the CMake include path can be specified as SYSTEM.