### PR TITLE
Add mp_rotate_left and mp_rotate_right

### DIFF
--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -1101,6 +1101,59 @@ struct mp_starts_with_impl<L1<T1...>, L2<T2...> > {
 template<class L1, class L2>
 using mp_starts_with = typename detail::mp_starts_with_impl<L1, L2>::type;
 
+// mp_rotate_left(_c)<L, N>
+namespace detail
+{
+
+template<class L, std::size_t N> struct canonical_rotation
+{
+    // provide a default rotation so that "no type named 'type'" errors appear in mp_rotate_impl instead of here
+    using type = mp_size_t<0>;
+};
+
+template<template<class...> class L, class... T, std::size_t N> struct canonical_rotation<L<T...>, N>
+{
+    // limit divisor to 1 to avoid division by 0 and give a rotation of 0 for lists containing 0 or 1 elements
+    using type = mp_size_t<N % (sizeof...(T) == 0 ? 1 : sizeof...(T))>;
+};
+
+template<class L, std::size_t N> using canonical_rotation_t = typename canonical_rotation<L, N>::type;
+
+struct left_rotation;
+struct right_rotation;
+
+template<class L, class N, class D> struct mp_rotate_impl
+{
+// An error "no type named 'type'" here means that the first argument to mp_rotate_left/mp_rotate_right is not a list
+};
+
+template<template<class...> class L, class... T> struct mp_rotate_impl<L<T...>, mp_size_t<0>, left_rotation>
+{
+    // fast-track the case of an identity rotation
+    using type = L<T...>;
+};
+
+template<template<class...> class L, class... T, std::size_t N> struct mp_rotate_impl<L<T...>, mp_size_t<N>, left_rotation>
+{
+    // avoid errors when rotating fixed-sized lists by using mp_list for the transformation
+    using type = mp_rename<mp_append<mp_drop_c<mp_list<T...>, N>, mp_take_c<mp_list<T...>, N>>, L>;
+};
+
+template<template<class...> class L, class... T, std::size_t N> struct mp_rotate_impl<L<T...>, mp_size_t<N>, right_rotation>
+{
+    // perform right rotation as a left rotation by inverting the number of elements to rotate
+    using type = typename mp_rotate_impl<L<T...>, canonical_rotation_t<L<T...>, sizeof...(T) - N>, left_rotation>::type;
+};
+
+} // namespace detail
+
+template<class L, std::size_t N = 1> using mp_rotate_left_c = typename detail::mp_rotate_impl<L, detail::canonical_rotation_t<L, N>, detail::left_rotation>::type;
+template<class L, class N = mp_size_t<1>> using mp_rotate_left = mp_rotate_left_c<L, std::size_t{ N::value }>;
+
+// mp_rotate_right(_c)<L, N>
+template<class L, std::size_t N = 1> using mp_rotate_right_c = typename detail::mp_rotate_impl<L, detail::canonical_rotation_t<L, N>, detail::right_rotation>::type;
+template<class L, class N = mp_size_t<1>> using mp_rotate_right = mp_rotate_right_c<L, std::size_t{ N::value }>;
+
 // mp_min_element<L, P>
 // mp_max_element<L, P>
 //   in detail/mp_min_element.hpp

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -117,6 +117,8 @@ run mp_nth_element_q.cpp ;
 run mp_back.cpp ;
 run mp_pop_back.cpp ;
 run mp_flatten.cpp ;
+run mp_rotate_left.cpp ;
+run mp_rotate_right.cpp ;
 
 # integral
 run integral.cpp ;

--- a/test/mp_rotate_left.cpp
+++ b/test/mp_rotate_left.cpp
@@ -1,0 +1,151 @@
+
+//  Copyright 2015 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/integral.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+#include <type_traits>
+#include <tuple>
+#include <utility>
+
+struct X1 {};
+struct X2 {};
+struct X3 {};
+struct X4 {};
+struct X5 {};
+
+int main()
+{
+    using boost::mp11::mp_list;
+    using boost::mp11::mp_rotate_left;
+    using boost::mp11::mp_rotate_left_c;
+    using boost::mp11::mp_size_t;
+
+    {
+        using L1 = mp_list<>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 0>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 2>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 3>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 4>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<0>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<1>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<2>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<3>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<4>>, L1>));
+
+        using L2 = mp_list<X1, X2, X3, X4, X5>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2>, mp_list<X2, X3, X4, X5, X1>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 0>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 1>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 2>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 3>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 4>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 5>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 6>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 7>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 8>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 9>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 10>, mp_list<X1, X2, X3, X4, X5>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<0>>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<1>>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<2>>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<3>>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<4>>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<5>>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<6>>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<7>>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<8>>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<9>>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<10>>, mp_list<X1, X2, X3, X4, X5>>));
+    }
+
+    {
+        using L1 = std::tuple<>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 0>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 2>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 3>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 4>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<0>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<1>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<2>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<3>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<4>>, L1>));
+
+        using L2 = std::tuple<X1, X2, X3, X4, X5>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2>, std::tuple<X2, X3, X4, X5, X1>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 0>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 1>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 2>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 3>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 4>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 5>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 6>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 7>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 8>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 9>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L2, 10>, std::tuple<X1, X2, X3, X4, X5>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<0>>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<1>>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<2>>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<3>>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<4>>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<5>>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<6>>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<7>>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<8>>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<9>>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L2, mp_size_t<10>>, std::tuple<X1, X2, X3, X4, X5>>));
+    }
+
+    {
+        using L1 = std::pair<X1, X2>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1>, std::pair<X2, X1>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 0>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 2>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 4>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 1>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 3>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left_c<L1, 5>, std::pair<X2, X1>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<0>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<2>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<4>>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<1>>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<3>>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_left<L1, mp_size_t<5>>, std::pair<X2, X1>>));
+    }
+
+    return boost::report_errors();
+}

--- a/test/mp_rotate_right.cpp
+++ b/test/mp_rotate_right.cpp
@@ -1,0 +1,151 @@
+
+//  Copyright 2015 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/integral.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+#include <type_traits>
+#include <tuple>
+#include <utility>
+
+struct X1 {};
+struct X2 {};
+struct X3 {};
+struct X4 {};
+struct X5 {};
+
+int main()
+{
+    using boost::mp11::mp_list;
+    using boost::mp11::mp_rotate_right;
+    using boost::mp11::mp_rotate_right_c;
+    using boost::mp11::mp_size_t;
+
+    {
+        using L1 = mp_list<>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 0>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 2>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 3>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 4>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<0>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<1>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<2>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<3>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<4>>, L1>));
+
+        using L2 = mp_list<X1, X2, X3, X4, X5>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2>, mp_list<X5, X1, X2, X3, X4>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 0>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 1>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 2>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 3>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 4>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 5>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 6>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 7>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 8>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 9>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 10>, mp_list<X1, X2, X3, X4, X5>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<0>>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<1>>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<2>>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<3>>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<4>>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<5>>, mp_list<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<6>>, mp_list<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<7>>, mp_list<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<8>>, mp_list<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<9>>, mp_list<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<10>>, mp_list<X1, X2, X3, X4, X5>>));
+    }
+
+    {
+        using L1 = std::tuple<>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 0>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 1>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 2>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 3>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 4>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<0>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<1>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<2>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<3>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<4>>, L1>));
+
+        using L2 = std::tuple<X1, X2, X3, X4, X5>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2>, std::tuple<X5, X1, X2, X3, X4>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 0>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 1>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 2>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 3>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 4>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 5>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 6>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 7>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 8>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 9>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L2, 10>, std::tuple<X1, X2, X3, X4, X5>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<0>>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<1>>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<2>>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<3>>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<4>>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<5>>, std::tuple<X1, X2, X3, X4, X5>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<6>>, std::tuple<X5, X1, X2, X3, X4>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<7>>, std::tuple<X4, X5, X1, X2, X3>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<8>>, std::tuple<X3, X4, X5, X1, X2>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<9>>, std::tuple<X2, X3, X4, X5, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L2, mp_size_t<10>>, std::tuple<X1, X2, X3, X4, X5>>));
+    }
+
+    {
+        using L1 = std::pair<X1, X2>;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1>, std::pair<X2, X1>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 0>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 2>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 4>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 1>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 3>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right_c<L1, 5>, std::pair<X2, X1>>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<0>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<2>>, L1>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<4>>, L1>));
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<1>>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<3>>, std::pair<X2, X1>>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<mp_rotate_right<L1, mp_size_t<5>>, std::pair<X2, X1>>));
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
I used mp11 to implement a list left rotation algorithm a while ago and having recently had cause to use it again (and extend it to cover some edge cases in my original implementaion) I thought I'd submit it here as a possible extension to the library. The implementation here is largely dictated by the SFINAE deficiencies of the Visual Studio 2013 compiler, as several versions of an alternative SFINAE-based implementation were fine for all the other test configurations. If you feel the fundamental idea has merit but I've missed a way to leverage the library more heavily to simplify the implementation then I'll happily put more time into making changes to it!