### PR TITLE
Tuple transform

### DIFF
--- a/doc/mp11/changelog.adoc
+++ b/doc/mp11/changelog.adoc
@@ -13,6 +13,7 @@ http://www.boost.org/LICENSE_1_0.txt
 ## Changes in 1.74.0
 
 * Improve compilation performance of `mp_with_index<N>` for large `N`
+* Added `tuple_transform` (contributed by Hans Dembinski)
 
 ## Changes in 1.73.0
 

--- a/doc/mp11/tuple.adoc
+++ b/doc/mp11/tuple.adoc
@@ -36,3 +36,9 @@ The name of the function doesn't match the {cpp}17 one to avoid ambiguities when
 expression `f(std::get<J>(std::forward<Tp>(tp)))` for `J` in 0..`N-1`, where `N` is `std::tuple_size<typename std::remove_reference<Tp>::type>::value`.
 
 Returns `std::forward<F>(f)`.
+
+## tuple_transform(tp, f)
+
+    template<class Tp, class F> constexpr /*...*/ tuple_transform(Tp&& tp, F&& f);
+
+`tuple_transform(tp, f)` applies the function object `f` to each element of `tp` by evaluating the expression `f(std::get<J>(std::forward<Tp>(tp)))` for `J` in 0..`N-1`, where `N` is `std::tuple_size<typename std::remove_reference<Tp>::type>::value` and constructs a new tuple that holds the results of these evaluations. `tuple_transform` also accepts `std::pair`. Warning: The evaluation order of the function object `f` is undefined.

--- a/doc/mp11/tuple.adoc
+++ b/doc/mp11/tuple.adoc
@@ -37,8 +37,12 @@ expression `f(std::get<J>(std::forward<Tp>(tp)))` for `J` in 0..`N-1`, where `N`
 
 Returns `std::forward<F>(f)`.
 
-## tuple_transform(tp, f)
+## tuple_transform(f, tp)
 
-    template<class Tp, class F> constexpr /*...*/ tuple_transform(Tp&& tp, F&& f);
+    template<class F, class Tp> constexpr /*...*/ tuple_transform(F&& f, Tp&& tp);
 
-`tuple_transform(tp, f)` applies the function object `f` to each element of `tp` by evaluating the expression `f(std::get<J>(std::forward<Tp>(tp)))` for `J` in 0..`N-1`, where `N` is `std::tuple_size<typename std::remove_reference<Tp>::type>::value` and constructs a new tuple that holds the results of these evaluations. `tuple_transform` also accepts `std::pair`. Warning: The evaluation order of the function object `f` is undefined.
+`tuple_transform(f, tp)` applies the function object `f` to each element of `tp` by evaluating the expression
+`f(std::get<J>(std::forward<Tp>(tp)))` for `J` in 0..`N-1`, where `N` is
+`std::tuple_size<typename std::remove_reference<Tp>::type>::value` and constructs a new
+tuple that holds the results of these evaluations. `tuple_transform` also accepts
+`std::pair`. Warning: The evaluation order of the function object `f` is undefined.

--- a/doc/mp11/tuple.adoc
+++ b/doc/mp11/tuple.adoc
@@ -39,10 +39,12 @@ Returns `std::forward<F>(f)`.
 
 ## tuple_transform(f, tp)
 
-    template<class F, class Tp> constexpr /*...*/ tuple_transform(F&& f, Tp&& tp);
+    template<class F, class... Tps> constexpr /*...*/ tuple_transform(F const& f, Tps const&... tps);
 
-`tuple_transform(f, tp)` applies the function object `f` to each element of `tp` by evaluating the expression
-`f(std::get<J>(std::forward<Tp>(tp)))` for `J` in 0..`N-1`, where `N` is
-`std::tuple_size<typename std::remove_reference<Tp>::type>::value` and constructs a new
-tuple that holds the results of these evaluations. `tuple_transform` also accepts
-`std::pair`. Warning: The evaluation order of the function object `f` is undefined.
+`tuple_transform(f, tps...)` accepts a function object `f` followed by one or more tuples of equal length
+(`std::pair` is also accepted). The callable `f` must accept as many arguments as there are tuples. The
+function object is called with the first elements of each tuple, then with the second element of each tuple,
+and so on, by evaluating the expression `f(std::get<J>(tps)...)` for `J` in 0..`N-1`, where `N` is
+`std::tuple_size<Tp>::value` for the first tuple `Tp`. The results are returned as a `Tp<Ts...>` with `Ts...`
+deduced from the return values of `f`. Warning: The order in which the elements of the tuples are processed
+is undefined. Calling `f` should not have side-effects.

--- a/include/boost/mp11/tuple.hpp
+++ b/include/boost/mp11/tuple.hpp
@@ -86,6 +86,31 @@ template<class Tp, class F> BOOST_MP11_CONSTEXPR F tuple_for_each( Tp && tp, F &
     return detail::tuple_for_each_impl( std::forward<Tp>(tp), seq(), std::forward<F>(f) );
 }
 
+// tuple_transform
+namespace detail
+{
+
+template<template<class...>class Tp, class... Ts, std::size_t... J, class F> BOOST_MP11_CONSTEXPR F tuple_transform_impl( Tp<Ts...> && tp, integer_sequence<std::size_t, J...>, F && f )
+{
+    // warning: evaluation order is platform-dependent
+    return Tp<
+      typename std::decay<decltype(f(std::declval<Ts>()))>::type...
+    >(f(std::get<J>(std::forward<Tp<Ts...>>(tp)))...);
+}
+
+template<class Tp, class F> BOOST_MP11_CONSTEXPR std::tuple<> tuple_transform_impl( Tp && /*tp*/, integer_sequence<std::size_t>, F && f )
+{
+    return {};
+}
+
+} // namespace detail
+
+template<class Tp, class F> BOOST_MP11_CONSTEXPR F tuple_transform( Tp && tp, F && f )
+{
+    using seq = make_index_sequence<std::tuple_size<typename std::remove_reference<Tp>::type>::value>;
+    return detail::tuple_transform_impl( std::forward<Tp>(tp), seq(), std::forward<F>(f) );
+}
+
 } // namespace mp11
 } // namespace boost
 

--- a/include/boost/mp11/tuple.hpp
+++ b/include/boost/mp11/tuple.hpp
@@ -91,57 +91,61 @@ namespace detail
 {
 
 template<
+  class F,
   template <class...> class Tp,
   class... Ts,
   std::size_t... J,
-  class F,
   class R = Tp<
     decltype(std::declval<F>()(std::declval<Ts>()))...
   >
 >
-BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> && tp, integer_sequence<std::size_t, J...>, F && f )
+BOOST_MP11_CONSTEXPR R tuple_transform_impl( F && f,
+  integer_sequence<std::size_t, J...>, Tp<Ts...> && tp )
 {
     return R(f(std::get<J>(std::move(tp)))...);
 }
 
 template<
+  class F,
   template <class...> class Tp,
   class... Ts,
   std::size_t... J,
-  class F,
   class R = Tp<
     decltype(std::declval<F>()(std::declval<Ts&>()))...
   >
 >
-BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> & tp, integer_sequence<std::size_t, J...>, F && f )
+BOOST_MP11_CONSTEXPR R tuple_transform_impl( F && f,
+  integer_sequence<std::size_t, J...>, Tp<Ts...> & tp )
 {
     return R(f(std::get<J>(tp))...);
 }
 
 template<
+  class F,
   template <class...> class Tp,
   class... Ts,
   std::size_t... J,
-  class F,
   class R = Tp<
     decltype(std::declval<F>()(std::declval<Ts const&>()))...
   >
 >
-BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> const& tp, integer_sequence<std::size_t, J...>, F && f )
+BOOST_MP11_CONSTEXPR R tuple_transform_impl( F && f,
+  integer_sequence<std::size_t, J...>, Tp<Ts...> const& tp )
 {
     return R(f(std::get<J>(tp))...);
 }
 
 template<
+  class F,
   template <class...> class Tp,
   class... Ts,
   std::size_t... J,
-  class F,
   class R = Tp<
     decltype(std::declval<F>()(std::declval<Ts const>()))...
   >
 >
-BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> const&& tp, integer_sequence<std::size_t, J...>, F && f )
+BOOST_MP11_CONSTEXPR R tuple_transform_impl( F && f,
+  integer_sequence<std::size_t, J...>, Tp<Ts...> const&& tp )
 {
     return R(f(std::get<J>(std::move(tp)))...);
 }
@@ -150,19 +154,20 @@ BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> const&& tp, integer_seque
 
 // warning: evaluation order is platform-dependent
 template<
-  class Tp,
   class F,
+  class Tp,
+  class... Tps,
   class Seq = make_index_sequence<
     std::tuple_size<typename std::remove_reference<Tp>::type>::value
   >
 >
-BOOST_MP11_CONSTEXPR auto tuple_transform( Tp && tp, F && f )
+BOOST_MP11_CONSTEXPR auto tuple_transform( F && f, Tp && tp, Tps &&... tps )
   -> decltype(detail::tuple_transform_impl(
-       std::forward<Tp>(tp), Seq(), std::forward<F>(f)
+       std::forward<F>(f), Seq(), std::forward<Tp>(tp), std::forward<Tps>(tps)...
      ))
 {
     return detail::tuple_transform_impl(
-      std::forward<Tp>(tp), Seq(), std::forward<F>(f)
+      std::forward<F>(f), Seq(), std::forward<Tp>(tp), std::forward<Tps>(tps)...
     );
 }
 

--- a/include/boost/mp11/tuple.hpp
+++ b/include/boost/mp11/tuple.hpp
@@ -96,11 +96,7 @@ template<
   std::size_t... J,
   class F,
   class R = Tp<
-    typename std::decay<
-      decltype(
-        std::declval<F>()(std::declval<Ts>())
-      )
-    >::type...
+    decltype(std::declval<F>()(std::declval<Ts>()))...
   >
 >
 BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> && tp, integer_sequence<std::size_t, J...>, F && f )
@@ -114,11 +110,7 @@ template<
   std::size_t... J,
   class F,
   class R = Tp<
-    typename std::decay<
-      decltype(
-        std::declval<F>()(std::declval<Ts&>())
-      )
-    >::type...
+    decltype(std::declval<F>()(std::declval<Ts&>()))...
   >
 >
 BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> & tp, integer_sequence<std::size_t, J...>, F && f )
@@ -132,16 +124,26 @@ template<
   std::size_t... J,
   class F,
   class R = Tp<
-    typename std::decay<
-      decltype(
-        std::declval<F>()(std::declval<Ts const&>())
-      )
-    >::type...
+    decltype(std::declval<F>()(std::declval<Ts const&>()))...
   >
 >
 BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> const& tp, integer_sequence<std::size_t, J...>, F && f )
 {
     return R(f(std::get<J>(tp))...);
+}
+
+template<
+  template <class...> class Tp,
+  class... Ts,
+  std::size_t... J,
+  class F,
+  class R = Tp<
+    decltype(std::declval<F>()(std::declval<Ts const>()))...
+  >
+>
+BOOST_MP11_CONSTEXPR R tuple_transform_impl( Tp<Ts...> const&& tp, integer_sequence<std::size_t, J...>, F && f )
+{
+    return R(f(std::get<J>(std::move(tp)))...);
 }
 
 } // namespace detail
@@ -155,9 +157,13 @@ template<
   >
 >
 BOOST_MP11_CONSTEXPR auto tuple_transform( Tp && tp, F && f )
-  -> decltype(detail::tuple_transform_impl( std::forward<Tp>(tp), Seq(), std::forward<F>(f) ))
+  -> decltype(detail::tuple_transform_impl(
+       std::forward<Tp>(tp), Seq(), std::forward<F>(f)
+     ))
 {
-    return detail::tuple_transform_impl( std::forward<Tp>(tp), Seq(), std::forward<F>(f) );
+    return detail::tuple_transform_impl(
+      std::forward<Tp>(tp), Seq(), std::forward<F>(f)
+    );
 }
 
 } // namespace mp11

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -156,6 +156,8 @@ run tuple_apply.cpp ;
 compile tuple_apply_cx.cpp ;
 run construct_from_tuple.cpp ;
 compile construct_from_tuple_cx.cpp ;
+run tuple_transform.cpp ;
+compile tuple_transform_cx.cpp ;
 
 # set
 run mp_set_contains.cpp ;

--- a/test/tuple_apply_cx.cpp
+++ b/test/tuple_apply_cx.cpp
@@ -1,11 +1,15 @@
 
-// Copyright 2020 Hans Dembinski.
+// Copyright 2015 Peter Dimov.
 //
 // Distributed under the Boost Software License, Version 1.0.
 //
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 
+
+#if defined(_MSC_VER)
+#pragma warning( disable: 4244 ) // 'initializing': conversion from 'int' to 'char', possible loss of data
+#endif
 
 #include <boost/mp11/tuple.hpp>
 #include <boost/mp11/detail/config.hpp>

--- a/test/tuple_transform.cpp
+++ b/test/tuple_transform.cpp
@@ -30,12 +30,7 @@ std::ostream& operator<<( std::ostream& os, T<N> const& t )
 
 // test function changes type and value
 struct F {
-    template <int N> T<N+1> operator()( T<N> t ) const
-    {
-        return T<N+1>{t.value + 2};
-    }
-
-    template <int N, int M> T<N+M> operator()( T<N> a, T<M> b ) const
+    template<int N, int M=1> T<N+M> operator()( T<N> a, T<M> b={} ) const
     {
         return T<N+M>{a.value + b.value + 1};
     }

--- a/test/tuple_transform.cpp
+++ b/test/tuple_transform.cpp
@@ -1,0 +1,94 @@
+
+// Copyright 2020 Hans Dembinski.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/mp11/tuple.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <tuple>
+#include <memory>
+#include <utility>
+#include <array>
+
+template <int N>
+struct T {
+    int value;
+    
+    T() = default;
+    T(int v) : value(v) {};
+    T& operator=(int v) { value = v; return *this; };
+    
+    operator int() const { return value; }
+};
+
+struct F {
+    template <int N>
+    T<N+1> operator()(const T<N>& t) const {
+        return t.value - 1;
+    }
+};
+
+int main()
+{
+    using boost::mp11::tuple_transform;
+
+    {
+        std::tuple<T<1>, T<2>> tp{ 2, 1 };
+
+        {
+            std::tuple<T<2>, T<3>> s = tuple_transform( F{}, tp );
+            BOOST_TEST_EQ( std::get<0>(s), 1 );
+            BOOST_TEST_EQ( std::get<1>(s), 0 );
+        }
+
+        {
+            std::tuple<T<2>, T<3>> s = tuple_transform( F{}, std::move(tp) );
+            BOOST_TEST_EQ( std::get<0>(s), 1 );
+            BOOST_TEST_EQ( std::get<1>(s), 0 );
+        }
+    }
+
+    {
+        std::tuple<T<1>, T<2>> const tp{ 2, 1 };
+
+        {
+            std::tuple<T<2>, T<3>> s = tuple_transform( F{}, tp );
+            BOOST_TEST_EQ( std::get<0>(s), 1 );
+            BOOST_TEST_EQ( std::get<1>(s), 0 );
+        }
+
+        {
+            std::tuple<T<2>, T<3>> s = tuple_transform( F{}, std::move(tp) );
+            BOOST_TEST_EQ( std::get<0>(s), 1 );
+            BOOST_TEST_EQ( std::get<1>(s), 0 );
+        }
+    }
+
+    {
+        std::pair<T<1>, T<2>> tp{ 2, 1 };
+
+        {
+            std::pair<T<2>, T<3>> s = tuple_transform( F{}, tp );
+            BOOST_TEST_EQ( std::get<0>(s), 1 );
+            BOOST_TEST_EQ( std::get<1>(s), 0 );
+        }
+
+        {
+            std::pair<T<2>, T<3>> s = tuple_transform( F{}, tp );
+            BOOST_TEST_EQ( std::get<0>(s), 1 );
+            BOOST_TEST_EQ( std::get<1>(s), 0 );
+        }
+    }
+
+    {
+        std::tuple<> tp;
+
+        BOOST_TEST_EQ( tuple_transform( F{}, tp ), std::tuple<>{} );
+        BOOST_TEST_EQ( tuple_transform( F{}, std::move( tp ) ), std::tuple<>{} );
+    }
+
+    return boost::report_errors();
+}

--- a/test/tuple_transform.cpp
+++ b/test/tuple_transform.cpp
@@ -30,24 +30,14 @@ std::ostream& operator<<( std::ostream& os, T<N> const& t )
 
 // test function changes type and value
 struct F {
-    template <int N> T<N+1> operator()( T<N> & t) const
+    template <int N> T<N+1> operator()( T<N> t ) const
     {
         return T<N+1>{t.value + 2};
     }
 
-    template <int N> T<N+1> operator()( T<N> && t) const
+    template <int N, int M> T<N+M> operator()( T<N> a, T<M> b ) const
     {
-        return T<N+1>{t.value + 3};
-    }
-
-    template <int N> T<N+1> operator()( T<N> const& t) const
-    {
-        return T<N+1>{t.value + 4};
-    }
-
-    template <int N> T<N+1> operator()( T<N> const&& t) const
-    {
-        return T<N+1>{t.value + 5};
+        return T<N+M>{a.value + b.value + 1};
     }
 };
 
@@ -57,6 +47,7 @@ int main()
 
     {
         std::tuple<T<1>, T<2>, T<3>> tp;
+        std::tuple<T<4>, T<5>, T<6>> tp2;
 
         {
             std::tuple<T<2>, T<3>, T<4>> s = tuple_transform( F{}, tp );
@@ -67,32 +58,66 @@ int main()
 
         {
             std::tuple<T<2>, T<3>, T<4>> s = tuple_transform( F{}, std::move(tp) );
-            BOOST_TEST_EQ( std::get<0>(s).value, 4 );
-            BOOST_TEST_EQ( std::get<1>(s).value, 5 );
-            BOOST_TEST_EQ( std::get<2>(s).value, 6 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 3 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 4 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 5 );
+        }
+
+        {
+            std::tuple<T<5>, T<7>, T<9>> s = tuple_transform( F{}, tp, tp2 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 6 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 8 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 10 );
+        }
+
+        {
+            std::tuple<T<5>, T<7>, T<9>> s = tuple_transform(
+                F{}, std::move(tp), std::move(tp2)
+            );
+            BOOST_TEST_EQ( std::get<0>(s).value, 6 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 8 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 10 );
         }
     }
 
     {
         std::tuple<T<1>, T<2>, T<3>> const tp;
+        std::tuple<T<4>, T<5>, T<6>> const tp2;
 
         {
             std::tuple<T<2>, T<3>, T<4>> s = tuple_transform( F{}, tp );
-            BOOST_TEST_EQ( std::get<0>(s).value, 5 );
-            BOOST_TEST_EQ( std::get<1>(s).value, 6 );
-            BOOST_TEST_EQ( std::get<2>(s).value, 7 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 3 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 4 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 5 );
         }
 
         {
             std::tuple<T<2>, T<3>, T<4>> s = tuple_transform( F{}, std::move(tp) );
+            BOOST_TEST_EQ( std::get<0>(s).value, 3 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 4 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 5 );
+        }
+
+        {
+            std::tuple<T<5>, T<7>, T<9>> s = tuple_transform( F{}, tp, tp2 );
             BOOST_TEST_EQ( std::get<0>(s).value, 6 );
-            BOOST_TEST_EQ( std::get<1>(s).value, 7 );
-            BOOST_TEST_EQ( std::get<2>(s).value, 8 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 8 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 10 );
+        }
+
+        {
+            std::tuple<T<5>, T<7>, T<9>> s = tuple_transform(
+                F{}, std::move(tp), std::move(tp2)
+            );
+            BOOST_TEST_EQ( std::get<0>(s).value, 6 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 8 );
+            BOOST_TEST_EQ( std::get<2>(s).value, 10 );
         }
     }
 
     {
         std::pair<T<1>, T<2>> tp;
+        std::pair<T<3>, T<4>> tp2;
 
         {
             std::pair<T<2>, T<3>> s = tuple_transform( F{}, tp );
@@ -102,23 +127,52 @@ int main()
 
         {
             std::pair<T<2>, T<3>> s = tuple_transform( F{}, std::move(tp) );
-            BOOST_TEST_EQ( std::get<0>(s).value, 4 );
-            BOOST_TEST_EQ( std::get<1>(s).value, 5 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 3 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 4 );
+        }
+
+        {
+            std::pair<T<4>, T<6>> s = tuple_transform( F{}, tp, tp2 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 5 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 7 );
+        }
+
+        {
+            std::pair<T<4>, T<6>> s = tuple_transform(
+                F{}, std::move(tp), std::move(tp2)
+            );
+            BOOST_TEST_EQ( std::get<0>(s).value, 5 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 7 );
         }
     }
 
     {
         std::pair<T<1>, T<2>> const tp;
+        std::pair<T<3>, T<4>> const tp2;
 
         {
             std::pair<T<2>, T<3>> s = tuple_transform( F{}, tp );
-            BOOST_TEST_EQ( std::get<0>(s).value, 5 );
-            BOOST_TEST_EQ( std::get<1>(s).value, 6 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 3 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 4 );
         }
 
         {
             std::pair<T<2>, T<3>> s = tuple_transform( F{}, std::move(tp) );
-            BOOST_TEST_EQ( std::get<0>(s).value, 6 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 3 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 4 );
+        }
+
+        {
+            std::pair<T<4>, T<6>> s = tuple_transform( F{}, tp, tp2 );
+            BOOST_TEST_EQ( std::get<0>(s).value, 5 );
+            BOOST_TEST_EQ( std::get<1>(s).value, 7 );
+        }
+
+        {
+            std::pair<T<4>, T<6>> s = tuple_transform(
+                F{}, std::move(tp), std::move(tp2)
+            );
+            BOOST_TEST_EQ( std::get<0>(s).value, 5 );
             BOOST_TEST_EQ( std::get<1>(s).value, 7 );
         }
     }

--- a/test/tuple_transform_cx.cpp
+++ b/test/tuple_transform_cx.cpp
@@ -1,11 +1,15 @@
 
-// Copyright 2020 Hans Dembinski.
+// Copyright 2015 Peter Dimov.
 //
 // Distributed under the Boost Software License, Version 1.0.
 //
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
 
+
+#if defined(_MSC_VER)
+#pragma warning( disable: 4244 ) // 'initializing': conversion from 'int' to 'char', possible loss of data
+#endif
 
 #include <boost/mp11/tuple.hpp>
 #include <boost/mp11/detail/config.hpp>
@@ -19,42 +23,23 @@ int main() {}
 #else
 
 #include <tuple>
-#include <array>
-#include <utility>
+#include <type_traits>
 
-constexpr int f( int x, int y, int z )
+struct assert_is_integral
 {
-    return x * 100 + y * 10 + z;
-}
-
-constexpr int g( int x, int y )
-{
-    return x * 10 + y;
-}
-
-constexpr int h()
-{
-    return 11;
-}
+    template<class T> constexpr bool operator()( T ) const
+    {
+        static_assert( std::is_integral<T>::value, "T must be an integral type" );
+        return true;
+    }
+};
 
 int main()
 {
     {
         constexpr std::tuple<int, short, char> tp{ 1, 2, 3 };
-        constexpr auto r = boost::mp11::tuple_apply( f, tp );
-        static_assert( r == 123, "r == 123" );
-    }
-
-    {
-        constexpr std::pair<short, char> tp{ 1, 2 };
-        constexpr auto r = boost::mp11::tuple_apply( g, tp );
-        static_assert( r == 12, "r == 12" );
-    }
-
-    {
-        constexpr std::array<short, 3> tp{{ 1, 2, 3 }};
-        constexpr auto r = boost::mp11::tuple_apply( f, tp );
-        static_assert( r == 123, "r == 123" );
+        constexpr auto r = boost::mp11::tuple_for_each( tp, assert_is_integral() );
+        (void)r;
     }
 
 #if defined( __clang_major__ ) && __clang_major__ == 3 && __clang_minor__ < 9
@@ -63,7 +48,7 @@ int main()
 
     {
         constexpr std::tuple<> tp;
-        constexpr auto r = boost::mp11::tuple_apply( h, tp );
+        constexpr auto r = boost::mp11::tuple_for_each( tp, 11 );
         static_assert( r == 11, "r == 11" );
     }
 

--- a/test/tuple_transform_cx.cpp
+++ b/test/tuple_transform_cx.cpp
@@ -1,15 +1,10 @@
 
-// Copyright 2015 Peter Dimov.
+// Copyright 2020 Hans Dembinski.
 //
 // Distributed under the Boost Software License, Version 1.0.
 //
 // See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt
-
-
-#if defined(_MSC_VER)
-#pragma warning( disable: 4244 ) // 'initializing': conversion from 'int' to 'char', possible loss of data
-#endif
 
 #include <boost/mp11/tuple.hpp>
 #include <boost/mp11/detail/config.hpp>
@@ -25,21 +20,21 @@ int main() {}
 #include <tuple>
 #include <type_traits>
 
-struct assert_is_integral
+struct F
 {
     template<class T> constexpr bool operator()( T ) const
     {
-        static_assert( std::is_integral<T>::value, "T must be an integral type" );
-        return true;
+        return std::is_integral<T>::value;
     }
 };
 
 int main()
 {
     {
-        constexpr std::tuple<int, short, char> tp{ 1, 2, 3 };
-        constexpr auto r = boost::mp11::tuple_for_each( tp, assert_is_integral() );
-        (void)r;
+        constexpr std::tuple<int, float> tp;
+        constexpr std::tuple<bool, bool> r = boost::mp11::tuple_transform( tp, F{} );
+        static_assert(std::get<0>(r).value == true, "get<0>(r).value == true" );
+        static_assert(std::get<1>(r).value == false, "get<1>(r).value == false" );
     }
 
 #if defined( __clang_major__ ) && __clang_major__ == 3 && __clang_minor__ < 9
@@ -48,8 +43,8 @@ int main()
 
     {
         constexpr std::tuple<> tp;
-        constexpr auto r = boost::mp11::tuple_for_each( tp, 11 );
-        static_assert( r == 11, "r == 11" );
+        constexpr std::tuple<> r = boost::mp11::tuple_transform( tp, F{} );
+        void(r);
     }
 
 #endif

--- a/test/tuple_transform_cx.cpp
+++ b/test/tuple_transform_cx.cpp
@@ -30,9 +30,9 @@ struct T {
 
 struct F
 {
-    template<int N> constexpr T<N+1> operator()( T<N> t ) const
+    template<int N, int M=1> constexpr T<N+M> operator()( T<N> a, T<M> b={} ) const
     {
-        return T<N+1>{t.value + 2};
+        return T<N+M>{a.value + b.value + 1};
     }
 };
 
@@ -40,9 +40,23 @@ int main()
 {
     {
         constexpr std::tuple<T<1>, T<2>> tp;
-        constexpr std::tuple<T<2>, T<3>> r = boost::mp11::tuple_transform( F{}, tp );
-        static_assert(std::get<0>(r).value == 3, "get<0>(r).value == 3" );
-        static_assert(std::get<1>(r).value == 4, "get<1>(r).value == 4" );
+        constexpr std::tuple<T<3>, T<4>> tp2;
+
+        {
+            constexpr std::tuple<T<2>, T<3>> r = boost::mp11::tuple_transform(
+                F{}, tp
+            );
+            static_assert(std::get<0>(r).value == 3, "get<0>(r).value == 3" );
+            static_assert(std::get<1>(r).value == 4, "get<1>(r).value == 4" );
+        }
+
+        {
+            constexpr std::tuple<T<4>, T<6>> r = boost::mp11::tuple_transform(
+                F{}, tp, tp2
+            );
+            static_assert(std::get<0>(r).value == 5, "get<0>(r).value == 5" );
+            static_assert(std::get<1>(r).value == 7, "get<1>(r).value == 7" );
+        }
     }
 
 #if defined( __clang_major__ ) && __clang_major__ == 3 && __clang_minor__ < 9

--- a/test/tuple_transform_cx.cpp
+++ b/test/tuple_transform_cx.cpp
@@ -20,21 +20,29 @@ int main() {}
 #include <tuple>
 #include <type_traits>
 
+// family of test types with state
+template <int N>
+struct T {
+    int value;
+    constexpr T() : value{N} {};
+    constexpr explicit T(int n) : value{n} {}
+};
+
 struct F
 {
-    template<class T> constexpr bool operator()( T ) const
+    template<int N> constexpr T<N+1> operator()( T<N> t ) const
     {
-        return std::is_integral<T>::value;
+        return T<N+1>{t.value + 2};
     }
 };
 
 int main()
 {
     {
-        constexpr std::tuple<int, float> tp;
-        constexpr std::tuple<bool, bool> r = boost::mp11::tuple_transform( tp, F{} );
-        static_assert(std::get<0>(r).value == true, "get<0>(r).value == true" );
-        static_assert(std::get<1>(r).value == false, "get<1>(r).value == false" );
+        constexpr std::tuple<T<1>, T<2>> tp;
+        constexpr std::tuple<T<2>, T<3>> r = boost::mp11::tuple_transform( F{}, tp );
+        static_assert(std::get<0>(r).value == 3, "get<0>(r).value == 3" );
+        static_assert(std::get<1>(r).value == 4, "get<1>(r).value == 4" );
     }
 
 #if defined( __clang_major__ ) && __clang_major__ == 3 && __clang_minor__ < 9
@@ -43,8 +51,8 @@ int main()
 
     {
         constexpr std::tuple<> tp;
-        constexpr std::tuple<> r = boost::mp11::tuple_transform( tp, F{} );
-        void(r);
+        constexpr std::tuple<> r = boost::mp11::tuple_transform( F{}, tp );
+        (void)r;
     }
 
 #endif


### PR DESCRIPTION
Adds `tuple_transform`, which applies a callable to each tuple element and stores the results in another tuple. Also works with std::pair, but not with std::array.
