### PR TITLE
Add a note to mp_for_each for lists with elements which are not default-constructible

### DIFF
--- a/doc/mp11/algorithm.adoc
+++ b/doc/mp11/algorithm.adoc
@@ -907,6 +907,8 @@ template<class... T> void print( std::tuple<T...> const & tp )
 }
 ```
 
+In case the elements of the list `L` are not default-constructible, you can use `mp_for_each<mp_transform<mp_identity, L>>`.
+
 ## mp_with_index<N>(i, f)
 
     template<std::size_t N, class F>


### PR DESCRIPTION
I ran into an issue with `mp_for_each`: My type list contained a `std::vector` but I was calling the `mp_for_each` in a `constexpr` context, compiling with C++17, which tried to instantiate the `std::vector` which is not `constexpr`.

Using `mp_for_each<mp_transform<mp_identity, L>>` as described in this issue was the perfect solution: https://github.com/boostorg/mp11/issues/23

Please add a hint for this to the documentation! Thank you!