### PR TITLE
Implement support for n-ary metafunctions in mp_compose

### DIFF
--- a/doc/mp11/utility.adoc
+++ b/doc/mp11/utility.adoc
@@ -295,7 +295,7 @@ As `mp_not_fn`, but takes a quoted metafunction.
 
 `mp_compose<F1, F2, ..., Fn>` is a quoted metafunction that applies
 `F1`, `F2`, ..., `Fn` to its argument, in sequence. That is,
-`mp_compose<F1, F2, ..., Fn>::fn<T>` is `Fn<...F2<F1<T>>...>`.
+`mp_compose<F1, F2, ..., Fn>::fn<T...>` is `Fn<...F2<F1<T...>>...>`.
 
 ## mp_compose_q<Q...>
 

--- a/include/boost/mp11/detail/mp_front.hpp
+++ b/include/boost/mp11/detail/mp_front.hpp
@@ -1,0 +1,42 @@
+#ifndef BOOST_MP11_DETAIL_MP_FRONT_HPP_INCLUDED
+#define BOOST_MP11_DETAIL_MP_FRONT_HPP_INCLUDED
+
+//  Copyright 2015-2021 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/mp11/detail/mp_list.hpp>
+#include <boost/mp11/utility.hpp>
+#include <boost/mp11/detail/config.hpp>
+
+namespace boost
+{
+namespace mp11
+{
+
+// mp_front<L>
+namespace detail
+{
+
+template<class L> struct mp_front_impl
+{
+// An error "no type named 'type'" here means that the argument to mp_front
+// is either not a list, or is an empty list
+};
+
+template<template<class...> class L, class T1, class... T> struct mp_front_impl<L<T1, T...>>
+{
+    using type = T1;
+};
+
+} // namespace detail
+
+template<class L> using mp_front = typename detail::mp_front_impl<L>::type;
+
+} // namespace mp11
+} // namespace boost
+
+#endif // #ifndef BOOST_MP11_DETAIL_MP_FRONT_HPP_INCLUDED

--- a/include/boost/mp11/detail/mp_rename.hpp
+++ b/include/boost/mp11/detail/mp_rename.hpp
@@ -1,0 +1,43 @@
+#ifndef BOOST_MP11_DETAIL_MP_RENAME_HPP_INCLUDED
+#define BOOST_MP11_DETAIL_MP_RENAME_HPP_INCLUDED
+
+//  Copyright 2015-2021 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/mp11/detail/config.hpp>
+
+namespace boost
+{
+namespace mp11
+{
+
+// mp_rename<L, B>
+namespace detail
+{
+
+template<class A, template<class...> class B> struct mp_rename_impl
+{
+// An error "no type named 'type'" here means that the first argument to mp_rename is not a list
+};
+
+template<template<class...> class A, class... T, template<class...> class B> struct mp_rename_impl<A<T...>, B>
+{
+    using type = B<T...>;
+};
+
+} // namespace detail
+
+template<class A, template<class...> class B> using mp_rename = typename detail::mp_rename_impl<A, B>::type;
+
+template<template<class...> class F, class L> using mp_apply = typename detail::mp_rename_impl<L, F>::type;
+
+template<class Q, class L> using mp_apply_q = typename detail::mp_rename_impl<L, Q::template fn>::type;
+
+} // namespace mp11
+} // namespace boost
+
+#endif // #ifndef BOOST_MP11_DETAIL_MP_RENAME_HPP_INCLUDED

--- a/include/boost/mp11/list.hpp
+++ b/include/boost/mp11/list.hpp
@@ -13,6 +13,7 @@
 #include <boost/mp11/detail/mp_is_list.hpp>
 #include <boost/mp11/detail/mp_append.hpp>
 #include <boost/mp11/detail/mp_front.hpp>
+#include <boost/mp11/detail/mp_rename.hpp>
 #include <boost/mp11/detail/config.hpp>
 #include <type_traits>
 
@@ -169,26 +170,9 @@ template<template<class...> class L, class... U, class... T> struct mp_push_back
 template<class L, class... T> using mp_push_back = typename detail::mp_push_back_impl<L, T...>::type;
 
 // mp_rename<L, B>
-namespace detail
-{
-
-template<class A, template<class...> class B> struct mp_rename_impl
-{
-// An error "no type named 'type'" here means that the first argument to mp_rename is not a list
-};
-
-template<template<class...> class A, class... T, template<class...> class B> struct mp_rename_impl<A<T...>, B>
-{
-    using type = B<T...>;
-};
-
-} // namespace detail
-
-template<class A, template<class...> class B> using mp_rename = typename detail::mp_rename_impl<A, B>::type;
-
-template<template<class...> class F, class L> using mp_apply = typename detail::mp_rename_impl<L, F>::type;
-
-template<class Q, class L> using mp_apply_q = typename detail::mp_rename_impl<L, Q::template fn>::type;
+// mp_apply<F, L>
+// mp_apply_q<Q, L>
+//   in detail/mp_rename.hpp
 
 // mp_replace_front<L, T>
 namespace detail

--- a/include/boost/mp11/list.hpp
+++ b/include/boost/mp11/list.hpp
@@ -12,6 +12,7 @@
 #include <boost/mp11/detail/mp_list.hpp>
 #include <boost/mp11/detail/mp_is_list.hpp>
 #include <boost/mp11/detail/mp_append.hpp>
+#include <boost/mp11/detail/mp_front.hpp>
 #include <boost/mp11/detail/config.hpp>
 #include <type_traits>
 
@@ -66,23 +67,7 @@ template<class L1, class L2> using mp_assign = typename detail::mp_assign_impl<L
 template<class L> using mp_clear = mp_assign<L, mp_list<>>;
 
 // mp_front<L>
-namespace detail
-{
-
-template<class L> struct mp_front_impl
-{
-// An error "no type named 'type'" here means that the argument to mp_front
-// is either not a list, or is an empty list
-};
-
-template<template<class...> class L, class T1, class... T> struct mp_front_impl<L<T1, T...>>
-{
-    using type = T1;
-};
-
-} // namespace detail
-
-template<class L> using mp_front = typename detail::mp_front_impl<L>::type;
+//   in detail/mp_front.hpp
 
 // mp_pop_front<L>
 namespace detail

--- a/include/boost/mp11/utility.hpp
+++ b/include/boost/mp11/utility.hpp
@@ -11,6 +11,8 @@
 #include <boost/mp11/integral.hpp>
 #include <boost/mp11/detail/mp_list.hpp>
 #include <boost/mp11/detail/mp_fold.hpp>
+#include <boost/mp11/detail/mp_front.hpp>
+#include <boost/mp11/detail/mp_rename.hpp>
 #include <boost/mp11/detail/config.hpp>
 
 namespace boost
@@ -233,7 +235,7 @@ template<class Q> using mp_not_fn_q = mp_not_fn<Q::template fn>;
 namespace detail
 {
 
-template<class T, class Q> using mp_reverse_invoke_q = mp_invoke_q<Q, T>;
+template<class L, class Q> using mp_compose_helper = mp_list< mp_apply_q<Q, L> >;
 
 } // namespace detail
 
@@ -241,14 +243,14 @@ template<class T, class Q> using mp_reverse_invoke_q = mp_invoke_q<Q, T>;
 
 template<template<class...> class... F> struct mp_compose
 {
-    template<class T> using fn = mp_fold<mp_list<mp_quote<F>...>, T, detail::mp_reverse_invoke_q>;
+    template<class... T> using fn = mp_front< mp_fold<mp_list<mp_quote<F>...>, mp_list<T...>, detail::mp_compose_helper> >;
 };
 
 #endif
 
 template<class... Q> struct mp_compose_q
 {
-    template<class T> using fn = mp_fold<mp_list<Q...>, T, detail::mp_reverse_invoke_q>;
+    template<class... T> using fn = mp_front< mp_fold<mp_list<Q...>, mp_list<T...>, detail::mp_compose_helper> >;
 };
 
 } // namespace mp11

--- a/test/mp_compose.cpp
+++ b/test/mp_compose.cpp
@@ -4,6 +4,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 
+#include <boost/mp11/list.hpp>
 #include <boost/mp11/utility.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 
@@ -14,6 +15,8 @@ template<class T> struct F3 {};
 template<class T> using G1 = F1<T>;
 template<class T> using G2 = F2<T>;
 template<class T> using G3 = F3<T>;
+
+template<class... T> struct H {};
 
 int main()
 {
@@ -32,6 +35,10 @@ int main()
     BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose<F1, F2, F3>::fn<void>, F3<F2<F1<void>>>>));
     BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose<G1, G2, G3>::fn<void>, F3<F2<F1<void>>>>));
 
+    BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose<H>::fn<int, char>, H<int, char>>));
+    BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose<H, F1>::fn<void, float>, F1<H<void, float>>>));
+    BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose<H, F1, G1>::fn<void, float>, G1<F1<H<void, float>>>>));
+
 #endif
 
     using QF1 = mp_quote<F1>;
@@ -41,6 +48,8 @@ int main()
     using QG1 = mp_quote<G1>;
     using QG2 = mp_quote<G2>;
     using QG3 = mp_quote<G3>;
+
+    using QH = mp_quote<H>;
 
     BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose_q<>::fn<void>, void>));
 
@@ -52,6 +61,10 @@ int main()
 
     BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose_q<QF1, QF2, QF3>::fn<void>, F3<F2<F1<void>>>>));
     BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose_q<QG1, QG2, QG3>::fn<void>, F3<F2<F1<void>>>>));
+
+    BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose_q<QH>::fn<int, char>, H<int, char>>));
+    BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose_q<QH, QF1>::fn<void, float>, F1<H<void, float>>>));
+    BOOST_TEST_TRAIT_TRUE((std::is_same<mp_compose_q<QH, QF1, QG1>::fn<void, float>, G1<F1<H<void, float>>>>));
 
     //
 


### PR DESCRIPTION
This makes `mp_compose<F, G>::fn<T...>` be equivalent to `G<F<T...>>`