### PR TITLE
Improve compilation speed by taking advantage of memoization

### DIFF
--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -205,13 +205,16 @@ template<class Qp, class Qf, class... L> using mp_transform_if_q = typename deta
 namespace detail
 {
 
-template<template<class...> class P, class L1, class... L> struct mp_filter_impl
+template<template<class...> class P> struct mp_filter_impl_f
 {
     using Qp = mp_quote<P>;
 
     template<class T1, class... T> using _f = mp_if< mp_invoke_q<Qp, T1, T...>, mp_list<T1>, mp_list<> >;
+};
 
-    using _t1 = mp_transform<_f, L1, L...>;
+template<template<class...> class P, class L1, class... L> struct mp_filter_impl
+{
+    using _t1 = mp_transform<mp_filter_impl_f<P>::template _f, L1, L...>;
     using _t2 = mp_apply<mp_append, _t1>;
 
     using type = mp_assign<L1, _t2>;

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -1202,13 +1202,16 @@ template<template<class...> class L> struct mp_power_set_impl< L<> >
 
 #endif
 
+template<class T1> struct mp_power_set_impl_f
+{
+    template<class L2> using _f = mp_push_front<L2, T1>;
+};
+
 template<template<class...> class L, class T1, class... T> struct mp_power_set_impl< L<T1, T...> >
 {
     using S1 = mp_power_set< L<T...> >;
 
-    template<class L2> using _f = mp_push_front<L2, T1>;
-
-    using S2 = mp_transform<_f, S1>;
+    using S2 = mp_transform<mp_power_set_impl_f<T1>::template _f, S1>;
 
     using type = mp_append< S1, S2 >;
 };

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -550,8 +550,7 @@ template<template<class...> class L, class... T, template<class...> class P, cla
     template<class U> struct _f { using type = mp_if<P<U>, W, U>; };
     using type = L<typename _f<T>::type...>;
 #else
-    template<class U> using _f = mp_if<P<U>, W, U>;
-    using type = L<_f<T>...>;
+    using type = L<mp_if<P<T>, W, T>...>;
 #endif
 };
 

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -172,7 +172,7 @@ template<template<class...> class F, template<class...> class L1, class... T1, t
 namespace detail
 {
 
-template<template<class...> class P, template<class...> class F, class... L> struct mp_transform_if_impl
+template<template<class...> class P, template<class...> class F> struct mp_transform_if_impl_f
 {
     // the stupid quote-unquote dance avoids "pack expansion used as argument for non-pack parameter of alias template"
 
@@ -189,8 +189,11 @@ template<template<class...> class P, template<class...> class F, class... L> str
     template<class... U> using _f = mp_eval_if_q<mp_not<mp_invoke_q<Qp, U...>>, mp_first<mp_list<U...>>, Qf, U...>;
 
 #endif
+};
 
-    using type = mp_transform<_f, L...>;
+template<template<class...> class P, template<class...> class F, class... L> struct mp_transform_if_impl
+{
+    using type = mp_transform<mp_transform_if_impl_f<P, F>::template _f, L...>;
 };
 
 } // namespace detail

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -153,13 +153,13 @@ template<class Q, class... L> using mp_transform_q = mp_transform<Q::template fn
 namespace detail
 {
 
+template<class V, class T> using mp_transform_push_back = mp_transform<mp_push_back, V, T>;
+
 template<template<class...> class F, template<class...> class L1, class... T1, template<class...> class L2, class... T2, template<class...> class L3, class... T3, template<class...> class L4, class... T4, class... L> struct mp_transform_impl<F, L1<T1...>, L2<T2...>, L3<T3...>, L4<T4...>, L...>
 {
     using A1 = L1<mp_list<T1, T2, T3, T4>...>;
 
-    template<class V, class T> using _f = mp_transform<mp_push_back, V, T>;
-
-    using A2 = mp_fold<mp_list<L...>, A1, _f>;
+    using A2 = mp_fold<mp_list<L...>, A1, mp_transform_push_back>;
 
     template<class T> using _g = mp_apply<F, T>;
 

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -1042,6 +1042,8 @@ template<class L, class Q> using mp_any_of_q = mp_any_of<L, Q::template fn>;
 namespace detail
 {
 
+#if ! BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
+
 template<class I> struct mp_replace_at_impl_p
 {
     template<class T1, class T2> using _p = std::is_same<T2, I>;
@@ -1052,12 +1054,24 @@ template<class W> struct mp_replace_at_impl_f
     template<class T1, class T2> using _f = W;
 };
 
+#endif
+
 template<class L, class I, class W> struct mp_replace_at_impl
 {
     static_assert( I::value >= 0, "mp_replace_at<L, I, W>: I must not be negative" );
 
+#if ! BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
+
+    template<class T1, class T2> using _p = std::is_same<T2, mp_size_t<I::value>>;
+    template<class T1, class T2> using _f = W;
+
+    using type = mp_transform_if<_p, _f, L, mp_iota<mp_size<L> > >;
+
+#else
 
     using type = mp_transform_if<mp_replace_at_impl_p<mp_size_t<I::value>>::template _p, mp_replace_at_impl_f<W>::template _f, L, mp_iota<mp_size<L> > >;
+
+#endif
 };
 
 } // namespace detail

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -573,8 +573,7 @@ template<template<class...> class L, class... T, class V> struct mp_remove_impl<
     template<class U> struct _f { using type = mp_if<std::is_same<U, V>, mp_list<>, mp_list<U>>; };
     using type = mp_append<L<>, typename _f<T>::type...>;
 #else
-    template<class U> using _f = mp_if<std::is_same<U, V>, mp_list<>, mp_list<U>>;
-    using type = mp_append<L<>, _f<T>...>;
+    using type = mp_append<L<>, mp_if<std::is_same<T, V>, mp_list<>, mp_list<T>>...>;
 #endif
 };
 

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -181,19 +181,19 @@ template<template<class...> class P, template<class...> class F> struct mp_trans
 
 #if BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1920 )
 
-    template<class... U> struct _f_ { using type = mp_eval_if_q<mp_not<mp_invoke_q<Qp, U...>>, mp_first<mp_list<U...>>, Qf, U...>; };
-    template<class... U> using _f = typename _f_<U...>::type;
+    template<class... U> struct _f { using type = mp_eval_if_q<mp_not<mp_invoke_q<Qp, U...>>, mp_first<mp_list<U...>>, Qf, U...>; };
+    template<class... U> using fn = typename _f<U...>::type;
 
 #else
 
-    template<class... U> using _f = mp_eval_if_q<mp_not<mp_invoke_q<Qp, U...>>, mp_first<mp_list<U...>>, Qf, U...>;
+    template<class... U> using fn = mp_eval_if_q<mp_not<mp_invoke_q<Qp, U...>>, mp_first<mp_list<U...>>, Qf, U...>;
 
 #endif
 };
 
 template<template<class...> class P, template<class...> class F, class... L> struct mp_transform_if_impl
 {
-    using type = mp_transform<mp_transform_if_impl_f<P, F>::template _f, L...>;
+    using type = mp_transform_q<mp_transform_if_impl_f<P, F>, L...>;
 };
 
 } // namespace detail
@@ -209,12 +209,12 @@ template<template<class...> class P> struct mp_filter_impl_f
 {
     using Qp = mp_quote<P>;
 
-    template<class T1, class... T> using _f = mp_if< mp_invoke_q<Qp, T1, T...>, mp_list<T1>, mp_list<> >;
+    template<class T1, class... T> using fn = mp_if<mp_invoke_q<Qp, T1, T...>, mp_list<T1>, mp_list<> >;
 };
 
 template<template<class...> class P, class L1, class... L> struct mp_filter_impl
 {
-    using _t1 = mp_transform<mp_filter_impl_f<P>::template _f, L1, L...>;
+    using _t1 = mp_transform_q<mp_filter_impl_f<P>, L1, L...>;
     using _t2 = mp_apply<mp_append, _t1>;
 
     using type = mp_assign<L1, _t2>;
@@ -650,12 +650,12 @@ template<template<class...> class L, class T1, template<class...> class P> struc
 
 template<class T1, template<class...> class P> struct mp_sort_impl_f
 {
-    template<class U> using f = P<U, T1>;
+    template<class U> using fn = P<U, T1>;
 };
 
 template<template<class...> class L, class T1, class... T, template<class...> class P> struct mp_sort_impl<L<T1, T...>, P>
 {
-    using part = mp_partition<L<T...>, mp_sort_impl_f<T1, P>::template f>;
+    using part = mp_partition_q<L<T...>, mp_sort_impl_f<T1, P>>;
 
     using S1 = typename mp_sort_impl<mp_first<part>, P>::type;
     using S2 = typename mp_sort_impl<mp_second<part>, P>::type;
@@ -1046,12 +1046,12 @@ namespace detail
 
 template<class I> struct mp_replace_at_impl_p
 {
-    template<class T1, class T2> using _p = std::is_same<T2, I>;
+    template<class T1, class T2> using fn = std::is_same<T2, I>;
 };
 
 template<class W> struct mp_replace_at_impl_f
 {
-    template<class T1, class T2> using _f = W;
+    template<class T1, class T2> using fn = W;
 };
 
 #endif
@@ -1069,7 +1069,7 @@ template<class L, class I, class W> struct mp_replace_at_impl
 
 #else
 
-    using type = mp_transform_if<mp_replace_at_impl_p<mp_size_t<I::value>>::template _p, mp_replace_at_impl_f<W>::template _f, L, mp_iota<mp_size<L> > >;
+    using type = mp_transform_if_q<mp_replace_at_impl_p<mp_size_t<I::value>>, mp_replace_at_impl_f<W>, L, mp_iota<mp_size<L> > >;
 
 #endif
 };
@@ -1218,14 +1218,14 @@ template<template<class...> class L> struct mp_power_set_impl< L<> >
 
 template<class T1> struct mp_power_set_impl_f
 {
-    template<class L2> using _f = mp_push_front<L2, T1>;
+    template<class L2> using fn = mp_push_front<L2, T1>;
 };
 
 template<template<class...> class L, class T1, class... T> struct mp_power_set_impl< L<T1, T...> >
 {
     using S1 = mp_power_set< L<T...> >;
 
-    using S2 = mp_transform<mp_power_set_impl_f<T1>::template _f, S1>;
+    using S2 = mp_transform_q<mp_power_set_impl_f<T1>, S1>;
 
     using type = mp_append< S1, S2 >;
 };

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -648,11 +648,14 @@ template<template<class...> class L, class T1, template<class...> class P> struc
     using type = L<T1>;
 };
 
+template<class T1, template<class...> class P> struct mp_sort_impl_f
+{
+    template<class U> using f = P<U, T1>;
+};
+
 template<template<class...> class L, class T1, class... T, template<class...> class P> struct mp_sort_impl<L<T1, T...>, P>
 {
-    template<class U> using F = P<U, T1>;
-
-    using part = mp_partition<L<T...>, F>;
+    using part = mp_partition<L<T...>, mp_sort_impl_f<T1, P>::template f>;
 
     using S1 = typename mp_sort_impl<mp_first<part>, P>::type;
     using S2 = typename mp_sort_impl<mp_second<part>, P>::type;

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -172,7 +172,7 @@ template<template<class...> class F, template<class...> class L1, class... T1, t
 namespace detail
 {
 
-template<template<class...> class P, template<class...> class F> struct mp_transform_if_impl_f
+template<template<class...> class P, template<class...> class F> struct mp_transform_if_impl
 {
     // the stupid quote-unquote dance avoids "pack expansion used as argument for non-pack parameter of alias template"
 
@@ -191,15 +191,10 @@ template<template<class...> class P, template<class...> class F> struct mp_trans
 #endif
 };
 
-template<template<class...> class P, template<class...> class F, class... L> struct mp_transform_if_impl
-{
-    using type = mp_transform_q<mp_transform_if_impl_f<P, F>, L...>;
-};
-
 } // namespace detail
 
-template<template<class...> class P, template<class...> class F, class... L> using mp_transform_if = typename detail::mp_transform_if_impl<P, F, L...>::type;
-template<class Qp, class Qf, class... L> using mp_transform_if_q = typename detail::mp_transform_if_impl<Qp::template fn, Qf::template fn, L...>::type;
+template<template<class...> class P, template<class...> class F, class... L> using mp_transform_if = mp_transform_q<detail::mp_transform_if_impl<P, F>, L...>;
+template<class Qp, class Qf, class... L> using mp_transform_if_q = mp_transform_q<detail::mp_transform_if_impl<Qp::template fn, Qf::template fn>, L...>;
 
 // mp_filter<P, L...>
 namespace detail

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -1042,14 +1042,22 @@ template<class L, class Q> using mp_any_of_q = mp_any_of<L, Q::template fn>;
 namespace detail
 {
 
+template<class I> struct mp_replace_at_impl_p
+{
+    template<class T1, class T2> using _p = std::is_same<T2, I>;
+};
+
+template<class W> struct mp_replace_at_impl_f
+{
+    template<class T1, class T2> using _f = W;
+};
+
 template<class L, class I, class W> struct mp_replace_at_impl
 {
     static_assert( I::value >= 0, "mp_replace_at<L, I, W>: I must not be negative" );
 
-    template<class T1, class T2> using _p = std::is_same<T2, mp_size_t<I::value>>;
-    template<class T1, class T2> using _f = W;
 
-    using type = mp_transform_if<_p, _f, L, mp_iota<mp_size<L> > >;
+    using type = mp_transform_if<mp_replace_at_impl_p<mp_size_t<I::value>>::template _p, mp_replace_at_impl_f<W>::template _f, L, mp_iota<mp_size<L> > >;
 };
 
 } // namespace detail

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -679,9 +679,7 @@ template<template<class...> class L, class T1, class... T, std::size_t I, templa
 {
     static_assert( I < 1 + sizeof...(T), "mp_nth_element index out of range" );
 
-    template<class U> using F = P<U, T1>;
-
-    using part = mp_partition<L<T...>, F>;
+    using part = mp_partition_q<L<T...>, mp_sort_impl_f<T1, P>>;
 
     using L1 = mp_first<part>;
     static std::size_t const N1 = mp_size<L1>::value;

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -1288,15 +1288,18 @@ template<class L, template<class...> class F> using mp_pairwise_fold = mp_pairwi
 namespace detail
 {
 
+template<class L, std::size_t M> struct mp_sliding_fold_impl_f
+{
+    template<class I> using fn = mp_slice_c<L, I::value, I::value + M>;
+};
+
 template<class C, class L, class Q, class S> struct mp_sliding_fold_impl;
 
 template<class L, class N, class Q> struct mp_sliding_fold_impl<mp_true, L, N, Q>
 {
     static const std::size_t M = mp_size<L>::value - N::value + 1;
 
-    template<class I> using F = mp_slice_c<L, I::value, I::value + M>;
-
-    using J = mp_transform<F, mp_iota<N>>;
+    using J = mp_transform_q<mp_sliding_fold_impl_f<L, M>, mp_iota<N>>;
 
     using type = mp_apply<mp_transform_q, mp_push_front<J, Q>>;
 };

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -529,8 +529,7 @@ template<template<class...> class L, class... T, class V, class W> struct mp_rep
     template<class A> struct _f { using type = mp_if<std::is_same<A, V>, W, A>; };
     using type = L<typename _f<T>::type...>;
 #else
-    template<class A> using _f = mp_if<std::is_same<A, V>, W, A>;
-    using type = L<_f<T>...>;
+    using type = L<mp_if<std::is_same<T, V>, W, T>...>;
 #endif
 };
 

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -1060,7 +1060,7 @@ template<class L, class I, class W> struct mp_replace_at_impl
 {
     static_assert( I::value >= 0, "mp_replace_at<L, I, W>: I must not be negative" );
 
-#if ! BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
+#if BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
 
     template<class T1, class T2> using _p = std::is_same<T2, mp_size_t<I::value>>;
     template<class T1, class T2> using _f = W;

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -335,11 +335,14 @@ namespace detail
 
 template<class L, class L2, class En> struct mp_drop_impl;
 
-template<template<class...> class L, class... T, template<class...> class L2, class... U> struct mp_drop_impl<L<T...>, L2<U...>, mp_true>
+template<template<class...> class L, class... U> struct mp_drop_impl_f
 {
     template<class... W> static mp_identity<L<W...>> f( U*..., mp_identity<W>*... );
+};
 
-    using R = decltype( f( static_cast<mp_identity<T>*>(0) ... ) );
+template<template<class...> class L, class... T, template<class...> class L2, class... U> struct mp_drop_impl<L<T...>, L2<U...>, mp_true>
+{
+    using R = decltype( mp_drop_impl_f<L, U...>::f( static_cast<mp_identity<T>*>(0) ... ) );
 
     using type = typename R::type;
 };

--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -229,6 +229,8 @@ template<class L, class V> struct mp_fill_impl
 // An error "no type named 'type'" here means that the L argument of mp_fill is not a list
 };
 
+template<class T, class> using mp_fill_first_item = T;
+
 template<template<class...> class L, class... T, class V> struct mp_fill_impl<L<T...>, V>
 {
 #if BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, <= 1900 )
@@ -238,8 +240,7 @@ template<template<class...> class L, class... T, class V> struct mp_fill_impl<L<
 
 #else
 
-    template<class...> using _f = V;
-    using type = L<_f<T>...>;
+    using type = L<mp_fill_first_item<V, T>...>;
 
 #endif
 };

--- a/include/boost/mp11/detail/mp_copy_if.hpp
+++ b/include/boost/mp11/detail/mp_copy_if.hpp
@@ -32,8 +32,7 @@ template<template<class...> class L, class... T, template<class...> class P> str
     template<class U> struct _f { using type = mp_if<P<U>, mp_list<U>, mp_list<>>; };
     using type = mp_append<L<>, typename _f<T>::type...>;
 #else
-    template<class U> using _f = mp_if<P<U>, mp_list<U>, mp_list<>>;
-    using type = mp_append<L<>, _f<T>...>;
+    using type = mp_append<L<>, mp_if<P<T>, mp_list<T>, mp_list<>>...>;
 #endif
 };
 

--- a/include/boost/mp11/detail/mp_map_find.hpp
+++ b/include/boost/mp11/detail/mp_map_find.hpp
@@ -99,14 +99,17 @@ template<class T> using mpmf_unwrap = typename mpmf_unwrap_impl<T>::type;
 
 template<class M, class K> struct mp_map_find_impl;
 
+template<class K> struct mp_map_find_impl_f
+{
+    template<template<class...> class L, class... U> static mp_identity<L<K, U...>> f( mp_identity<L<K, U...>>* );
+    static mp_identity<void> f( ... );
+};
+
 template<template<class...> class M, class... T, class K> struct mp_map_find_impl<M<T...>, K>
 {
     using U = mp_inherit<mpmf_wrap<T>...>;
 
-    template<template<class...> class L, class... U> static mp_identity<L<K, U...>> f( mp_identity<L<K, U...>>* );
-    static mp_identity<void> f( ... );
-
-    using type = mpmf_unwrap< decltype( f( static_cast<U*>(0) ) ) >;
+    using type = mpmf_unwrap< decltype( mp_map_find_impl_f<K>::f( static_cast<U*>(0) ) ) >;
 };
 
 } // namespace detail

--- a/include/boost/mp11/detail/mp_map_find.hpp
+++ b/include/boost/mp11/detail/mp_map_find.hpp
@@ -11,7 +11,8 @@
 #include <boost/mp11/utility.hpp>
 #include <boost/mp11/detail/config.hpp>
 
-#if BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, >= 140000 )
+#if (BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, >= 140000 ) && BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, < 140400 )) \
+ || (BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, >= 150000 ) && BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, < 150200 ))
 
 #include <boost/mp11/detail/mp_list.hpp>
 #include <boost/mp11/detail/mp_append.hpp>
@@ -34,7 +35,8 @@ namespace boost
 namespace mp11
 {
 
-#if BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, >= 140000 )
+#if (BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, >= 140000 ) && BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, < 140400 )) \
+ || (BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, >= 150000 ) && BOOST_MP11_WORKAROUND( BOOST_MP11_GCC, < 150200 ))
 
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120161
 

--- a/include/boost/mp11/detail/mp_map_find.hpp
+++ b/include/boost/mp11/detail/mp_map_find.hpp
@@ -41,13 +41,16 @@ namespace mp11
 namespace detail
 {
 
+template<class K, class T> struct mp_map_find_impl_k
+{
+    using type = mp_if<std::is_same<mp_front<T>, K>, mp_list<T>, mp_list<>>;
+};
+
 template<class M, class K> struct mp_map_find_impl;
 
 template<template<class...> class M, class... T, class K> struct mp_map_find_impl<M<T...>, K>
 {
-    template<class U> using _f = mp_if<std::is_same<mp_front<U>, K>, mp_list<U>, mp_list<>>;
-
-    using _l = mp_append<_f<T>..., mp_list<void>>;
+    using _l = mp_append<typename mp_map_find_impl_k<K, T>::type..., mp_list<void>>;
 
     using type = mp_front<_l>;
 };

--- a/include/boost/mp11/detail/mp_remove_if.hpp
+++ b/include/boost/mp11/detail/mp_remove_if.hpp
@@ -32,8 +32,7 @@ template<template<class...> class L, class... T, template<class...> class P> str
     template<class U> struct _f { using type = mp_if<P<U>, mp_list<>, mp_list<U>>; };
     using type = mp_append<L<>, typename _f<T>::type...>;
 #else
-    template<class U> using _f = mp_if<P<U>, mp_list<>, mp_list<U>>;
-    using type = mp_append<L<>, _f<T>...>;
+    using type = mp_append<L<>, mp_if<P<T>, mp_list<>, mp_list<T>>...>;
 #endif
 };
 

--- a/include/boost/mp11/integer_sequence.hpp
+++ b/include/boost/mp11/integer_sequence.hpp
@@ -19,6 +19,8 @@
 #if defined(__has_builtin)
 # if __has_builtin(__make_integer_seq)
 #  define BOOST_MP11_HAS_MAKE_INTEGER_SEQ
+# elif __has_builtin(__integer_pack)
+#  define BOOST_MP11_HAS_INTEGER_PACK
 # endif
 #endif
 
@@ -35,6 +37,10 @@ template<class T, T... I> struct integer_sequence
 #if defined(BOOST_MP11_HAS_MAKE_INTEGER_SEQ)
 
 template<class T, T N> using make_integer_sequence = __make_integer_seq<integer_sequence, T, N>;
+
+#elif defined(BOOST_MP11_HAS_INTEGER_PACK)
+
+template<class T, T N> using make_integer_sequence = integer_sequence<T, __integer_pack(N)...>;
 
 #else
 

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -78,10 +78,14 @@ template<class M, class T, class Q> using mp_map_update_q = mp_map_update<M, T, 
 namespace detail
 {
 
-template<class M, class K> struct mp_map_erase_impl
+template<class K> struct mp_map_erase_impl_f
 {
     template<class T> using _f = std::is_same<mp_first<T>, K>;
-    using type = mp_remove_if<M, _f>;
+};
+
+template<class M, class K> struct mp_map_erase_impl
+{
+    using type = mp_remove_if<M, mp_map_erase_impl_f<K>::template _f>;
 };
 
 } // namespace detail

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -38,11 +38,19 @@ template<template<class...> class M, class... U, class T> struct mp_map_replace_
 {
     using K = mp_first<T>;
 
-    // mp_replace_if is inlined here using a struct _f because of msvc-14.0
+#if BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1920 )
 
     template<class V> struct _f { using type = mp_if< std::is_same<mp_first<V>, K>, T, V >; };
 
     using type = mp_if< mp_map_contains<M<U...>, K>, M<typename _f<U>::type...>, M<U..., T> >;
+
+#else
+
+    template<class V> using _f = mp_if< std::is_same<mp_first<V>, K>, T, V >;
+
+    using type = mp_if< mp_map_contains<M<U...>, K>, M<_f<U>...>, M<U..., T> >;
+
+#endif
 };
 
 } // namespace detail

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -61,6 +61,8 @@ template<class M, class T> using mp_map_replace = typename detail::mp_map_replac
 namespace detail
 {
 
+#if ! BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
+
 template<class T> struct mp_map_update_impl_f
 {
     template<class U> using _f = std::is_same<mp_first<T>, mp_first<U>>;
@@ -72,9 +74,24 @@ template<template<class...> class F> struct mp_map_update_impl_f3
     template<class L> using _f3 = mp_assign<L, mp_list<mp_first<L>, mp_rename<L, F> > >;
 };
 
+#endif
+
 template<class M, class T, template<class...> class F> struct mp_map_update_impl
 {
+#if BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
+
+    template<class U> using _f = std::is_same<mp_first<T>, mp_first<U>>;
+
+    // _f3<L<X, Y...>> -> L<X, F<X, Y...>>
+    template<class L> using _f3 = mp_assign<L, mp_list<mp_first<L>, mp_rename<L, F> > >;
+
+    using type = mp_if< mp_map_contains<M, mp_first<T>>, mp_transform_if<_f, _f3, M>, mp_push_back<M, T> >;
+
+#else
+
     using type = mp_if< mp_map_contains<M, mp_first<T>>, mp_transform_if<mp_map_update_impl_f<T>::template _f, mp_map_update_impl_f3<F>::template _f3, M>, mp_push_back<M, T> >;
+
+#endif
 };
 
 } // namespace detail

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -53,14 +53,20 @@ template<class M, class T> using mp_map_replace = typename detail::mp_map_replac
 namespace detail
 {
 
-template<class M, class T, template<class...> class F> struct mp_map_update_impl
+template<class T> struct mp_map_update_impl_f
 {
     template<class U> using _f = std::is_same<mp_first<T>, mp_first<U>>;
+};
 
+template<template<class...> class F> struct mp_map_update_impl_f3
+{
     // _f3<L<X, Y...>> -> L<X, F<X, Y...>>
     template<class L> using _f3 = mp_assign<L, mp_list<mp_first<L>, mp_rename<L, F> > >;
+};
 
-    using type = mp_if< mp_map_contains<M, mp_first<T>>, mp_transform_if<_f, _f3, M>, mp_push_back<M, T> >;
+template<class M, class T, template<class...> class F> struct mp_map_update_impl
+{
+    using type = mp_if< mp_map_contains<M, mp_first<T>>, mp_transform_if<mp_map_update_impl_f<T>::template _f, mp_map_update_impl_f3<F>::template _f3, M>, mp_push_back<M, T> >;
 };
 
 } // namespace detail

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -70,7 +70,7 @@ template<class T> struct mp_map_update_impl_f
 
 template<template<class...> class F> struct mp_map_update_impl_f3
 {
-    // _f3<L<X, Y...>> -> L<X, F<X, Y...>>
+    // fn<L<X, Y...>> -> L<X, F<X, Y...>>
     template<class L> using fn = mp_assign<L, mp_list<mp_first<L>, mp_rename<L, F> > >;
 };
 
@@ -103,19 +103,14 @@ template<class M, class T, class Q> using mp_map_update_q = mp_map_update<M, T, 
 namespace detail
 {
 
-template<class K> struct mp_map_erase_impl_f
+template<class K> struct mp_map_erase_impl
 {
     template<class T> using fn = std::is_same<mp_first<T>, K>;
 };
 
-template<class M, class K> struct mp_map_erase_impl
-{
-    using type = mp_remove_if_q<M, mp_map_erase_impl_f<K>>;
-};
-
 } // namespace detail
 
-template<class M, class K> using mp_map_erase = typename detail::mp_map_erase_impl<M, K>::type;
+template<class M, class K> using mp_map_erase = mp_remove_if_q<M, detail::mp_map_erase_impl<K>>;
 
 // mp_map_keys<M>
 template<class M> using mp_map_keys = mp_transform<mp_first, M>;

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -46,9 +46,7 @@ template<template<class...> class M, class... U, class T> struct mp_map_replace_
 
 #else
 
-    template<class V> using _f = mp_if< std::is_same<mp_first<V>, K>, T, V >;
-
-    using type = mp_if< mp_map_contains<M<U...>, K>, M<_f<U>...>, M<U..., T> >;
+    using type = mp_if< mp_map_contains<M<U...>, K>, M<mp_if< std::is_same<mp_first<U>, K>, T, U >...>, M<U..., T> >;
 
 #endif
 };

--- a/include/boost/mp11/map.hpp
+++ b/include/boost/mp11/map.hpp
@@ -65,13 +65,13 @@ namespace detail
 
 template<class T> struct mp_map_update_impl_f
 {
-    template<class U> using _f = std::is_same<mp_first<T>, mp_first<U>>;
+    template<class U> using fn = std::is_same<mp_first<T>, mp_first<U>>;
 };
 
 template<template<class...> class F> struct mp_map_update_impl_f3
 {
     // _f3<L<X, Y...>> -> L<X, F<X, Y...>>
-    template<class L> using _f3 = mp_assign<L, mp_list<mp_first<L>, mp_rename<L, F> > >;
+    template<class L> using fn = mp_assign<L, mp_list<mp_first<L>, mp_rename<L, F> > >;
 };
 
 #endif
@@ -89,7 +89,7 @@ template<class M, class T, template<class...> class F> struct mp_map_update_impl
 
 #else
 
-    using type = mp_if< mp_map_contains<M, mp_first<T>>, mp_transform_if<mp_map_update_impl_f<T>::template _f, mp_map_update_impl_f3<F>::template _f3, M>, mp_push_back<M, T> >;
+    using type = mp_if< mp_map_contains<M, mp_first<T>>, mp_transform_if_q<mp_map_update_impl_f<T>, mp_map_update_impl_f3<F>, M>, mp_push_back<M, T> >;
 
 #endif
 };
@@ -105,12 +105,12 @@ namespace detail
 
 template<class K> struct mp_map_erase_impl_f
 {
-    template<class T> using _f = std::is_same<mp_first<T>, K>;
+    template<class T> using fn = std::is_same<mp_first<T>, K>;
 };
 
 template<class M, class K> struct mp_map_erase_impl
 {
-    using type = mp_remove_if<M, mp_map_erase_impl_f<K>::template _f>;
+    using type = mp_remove_if_q<M, mp_map_erase_impl_f<K>>;
 };
 
 } // namespace detail


### PR DESCRIPTION
I put in bulk the benchmarks and tests that can be found in each commit (issue #77)

(result of `/usr/bin/time --format='%Es - %MK' $compiler ...`)

## `mp_transform_if`

compiler |       gcc-12      |      clang-15
--|--|--
before   | 0:00.13s - 60432K | 0:00.16s - 100956K
after    | 0:00.11s - 47300K | 0:00.16s - 100484K

```cpp
template<class T> using p = mp_bool<T::value & 1>;
template<class T> using f = mp_size_t<T::value + 1>;
template<class I> using test = mp_transform_if<p, f, mp_iota<I>>;

using r1 = mp_transform<test, mp_iota_c<50>>;
```

## `mp_filter`

compiler |       gcc-12      |      clang-15
--|--|--
before   | 0:00.16s - 72460K | 0:00.16s - 102068K
after    | 0:00.14s - 61884K | 0:00.16s - 101828K

```cpp
template<class T> using p = mp_bool<T::value & 1>;
template<class I> using test = mp_filter<p, mp_iota<I>>;

using r1 = mp_transform<test, mp_iota_c<50>>;
```

## `mp_drop`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.48s - 192464K | 0:00.48s - 154480K
after    | 0:00.43s - 172472K | 0:00.46s - 150404K

```cpp
template<class L> struct f { template<class I> using g = mp_drop<L, I>; };
template<class I, class L = mp_iota<I>> using test = mp_transform<f<L>::template g, L>;

using r1 = mp_transform<test, mp_iota_c<50>>;
```

## `mp_sort`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.46s - 198848K | 0:00.49s - 132632K
after    | 0:00.42s - 183384K | 0:00.48s - 131748K

```cpp
template<class I> using test = mp_sort<mp_iota<I>, mp_less>;

using r1 = mp_transform<test, mp_iota_c<25>>;
```

## `mp_replace_at`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.34s - 134428K | 0:00.33s - 124720K
after    | 0:00.29s - 116920K | 0:00.32s - 122568K

```cpp
template<class I> using f = mp_replace_at<mp_iota<I>, I, void>;
template<class I> using test = mp_transform<f, mp_iota<I>>;

using r1 = mp_transform<test, mp_iota_c<50>>;
```

## `mp_power_set`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:01.35s - 538732K | 0:00.65s - 203924K
after    | 0:01.02s - 396032K | 0:00.65s - 203080K

```cpp
template<class I> using test = mp_power_set<mp_iota<I>>;

using r1 = mp_transform<test, mp_iota_c<15>>;
```

## `mp_map_find`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.29s - 128600K | 0:00.25s - 120604K
after    | 0:00.22s - 99908K  | 0:00.23s - 116084K

```cpp
template<class L, class M = mp_transform<mp_list, L>>
struct f { template<class I> using g = mp_map_find<M, I>; };

template<class I, class L = mp_iota<I>> using test
  = mp_transform<f<L>::template g, L>;

using r1 = mp_transform<test, mp_iota_c<50>>;
```

## `mp_map_update`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.73s - 270224K | 0:00.54s - 156112K
after    | 0:00.19s - 85004K  | 0:00.29s - 119232K

```cpp
template<class L, class M = mp_transform<mp_list, L>>
struct f { template<class I> using g = mp_map_update<M, mp_list<I>, mp_list>; };

template<class I, class L = mp_iota<I>> using test
  = mp_transform<f<L>::template g, L>;

using r1 = mp_transform<test, mp_iota_c<20>>;
```

## `mp_map_erase`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.52s - 197128K | 0:00.44s - 140780K
after    | 0:00.47s - 183968K | 0:00.43s - 139336K

```cpp
template<class L, class M = mp_transform<mp_list, L>>
struct f { template<class I> using g = mp_map_erase<M, I>; };

template<class I, class L = mp_iota<I>> using test
  = mp_transform<f<L>::template g, L>;

using r1 = mp_transform<test, mp_iota_c<30>>;
```

## `mp_map_replace`

compiler |       gcc-12       |      clang-15
--|--|--
before   | 0:00.46s - 187160K | 0:00.38s - 129104K
after    | 0:00.21s - 80236K  | 0:00.33s - 123644K

```cpp
template<class L, class M = mp_transform<mp_list, L>>
struct f { template<class I> using g = mp_map_replace<M, mp_list<I, I>>; };

template<class I, class L = mp_iota<I>> using test
  = mp_transform<f<L>::template g, L>;

using r1 = mp_transform<test, mp_iota_c<30>>;
```
