### PR TITLE
Remove usages of old style cast, use static_cast instead

### DIFF
--- a/include/boost/mp11/algorithm.hpp
+++ b/include/boost/mp11/algorithm.hpp
@@ -309,7 +309,7 @@ template<template<class...> class L, class... T, template<class...> class L2, cl
 {
     template<class... W> static mp_identity<L<W...>> f( U*..., mp_identity<W>*... );
 
-    using R = decltype( f( (mp_identity<T>*)0 ... ) );
+    using R = decltype( f( static_cast<mp_identity<T>*>(0) ... ) );
 
     using type = typename R::type;
 };

--- a/include/boost/mp11/detail/mp_map_find.hpp
+++ b/include/boost/mp11/detail/mp_map_find.hpp
@@ -74,7 +74,7 @@ template<template<class...> class M, class... T, class K> struct mp_map_find_imp
     template<template<class...> class L, class... U> static mp_identity<L<K, U...>> f( mp_identity<L<K, U...>>* );
     static mp_identity<void> f( ... );
 
-    using type = mpmf_unwrap< decltype( f((U*)0) ) >;
+    using type = mpmf_unwrap< decltype( f( static_cast<U*>(0) ) ) >;
 };
 
 } // namespace detail


### PR DESCRIPTION
This silences compiler warnings generated by GCC

Fixes #80 