### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,19 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/mp11
+    : common-requirements
+        <include>include
+    ;
+
+explicit
+    [ alias boost_mp11 ]
+    [ alias all : boost_mp11 test ]
+    ;
+
+call-if : boost-library mp11
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/mp11

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/mp11
     : common-requirements

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -6,11 +6,16 @@
 #  See accompanying file LICENSE_1_0.txt or copy at
 #  http://www.boost.org/LICENSE_1_0.txt
 
+import-search /boost/config/checks ;
+
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project
   : requirements
+    <source>/boost/config//boost_config
+    <source>/boost/core//boost_core
+    <source>/boost/mpl//boost_mpl
 
     [ requires cxx11_variadic_templates cxx11_template_aliases cxx11_decltype cxx11_hdr_tuple ]
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854
- https://github.com/boostorg/auto_index/pull/7
- https://github.com/boostorg/bcp/pull/20
- https://github.com/boostorg/boost_install/pull/69
- https://github.com/boostorg/boost/pull/890
- https://github.com/boostorg/boostbook/pull/25
- https://github.com/boostorg/boostdep/pull/21
- https://github.com/boostorg/docca/pull/143
- https://github.com/boostorg/inspect/pull/19
- https://github.com/boostorg/quickbook/pull/25

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.