### PR TITLE
Improved performance of  `mp_is_set`

### DIFF
--- a/include/boost/mp11/set.hpp
+++ b/include/boost/mp11/set.hpp
@@ -109,9 +109,19 @@ struct mp_is_set_helper: Base
     static mp_true contains( mp_identity<T> );
 };
 
+template<class S> struct mp_is_set_impl
+{
+    using type = mp_false;
+};
+
+template<template<class...> class L, class... T> struct mp_is_set_impl<L<T...>>
+{
+    using type = mp_bool<mp_fold<mp_list<T...>, detail::mp_is_set_helper_start, detail::mp_is_set_helper>::value>;
+};
+
 } // namespace detail
 
-template<class S> using mp_is_set = mp_bool<mp_fold<S, detail::mp_is_set_helper_start, detail::mp_is_set_helper>::value>;
+template<class S> using mp_is_set = typename detail::mp_is_set_impl<S>::type;
 
 // mp_set_union<L...>
 namespace detail

--- a/include/boost/mp11/set.hpp
+++ b/include/boost/mp11/set.hpp
@@ -1,7 +1,7 @@
 #ifndef BOOST_MP11_SET_HPP_INCLUDED
 #define BOOST_MP11_SET_HPP_INCLUDED
 
-// Copyright 2015, 2019 Peter Dimov.
+// Copyright 2015, 2019, 2024 Peter Dimov.
 //
 // Distributed under the Boost Software License, Version 1.0.
 //
@@ -94,19 +94,23 @@ template<class S, class... T> using mp_set_push_front = typename detail::mp_set_
 namespace detail
 {
 
-template<class S> struct mp_is_set_impl
+struct mp_is_set_helper_start
 {
-    using type = mp_false;
+    static constexpr bool value = true;
+    template<class T> static mp_false contains( T );
 };
 
-template<template<class...> class L, class... T> struct mp_is_set_impl<L<T...>>
+template<class Base, class T>
+struct mp_is_set_helper: Base
 {
-    using type = mp_to_bool<std::is_same<mp_list<T...>, mp_set_push_back<mp_list<>, T...> > >;
+    static constexpr bool value = Base::value && !decltype( Base::contains( mp_identity<T>{} ) )::value;
+    using Base::contains;
+    static mp_true contains( mp_identity<T> );
 };
 
 } // namespace detail
 
-template<class S> using mp_is_set = typename detail::mp_is_set_impl<S>::type;
+template<class S> using mp_is_set = mp_bool<mp_fold<S, detail::mp_is_set_helper_start, detail::mp_is_set_helper>::value>;
 
 // mp_set_union<L...>
 namespace detail

--- a/include/boost/mp11/set.hpp
+++ b/include/boost/mp11/set.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/mp11/utility.hpp>
 #include <boost/mp11/function.hpp>
+#include <boost/mp11/detail/config.hpp>
 #include <boost/mp11/detail/mp_list.hpp>
 #include <boost/mp11/detail/mp_append.hpp>
 #include <boost/mp11/detail/mp_copy_if.hpp>
@@ -95,6 +96,8 @@ template<class S, class... T> using mp_set_push_front = typename detail::mp_set_
 namespace detail
 {
 
+#if !BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
+
 struct mp_is_set_helper_start
 {
     static constexpr bool value = true;
@@ -118,6 +121,20 @@ template<template<class...> class L, class... T> struct mp_is_set_impl<L<T...>>
 {
     using type = mp_bool<mp_fold<mp_list<T...>, detail::mp_is_set_helper_start, detail::mp_is_set_helper>::value>;
 };
+
+#else
+
+template<class S> struct mp_is_set_impl
+{
+    using type = mp_false;
+};
+
+template<template<class...> class L, class... T> struct mp_is_set_impl<L<T...>>
+{
+    using type = mp_to_bool<std::is_same<mp_list<T...>, mp_set_push_back<mp_list<>, T...> > >;
+};
+
+#endif // !BOOST_MP11_WORKAROUND( BOOST_MP11_MSVC, < 1900 )
 
 } // namespace detail
 

--- a/include/boost/mp11/set.hpp
+++ b/include/boost/mp11/set.hpp
@@ -13,6 +13,7 @@
 #include <boost/mp11/detail/mp_list.hpp>
 #include <boost/mp11/detail/mp_append.hpp>
 #include <boost/mp11/detail/mp_copy_if.hpp>
+#include <boost/mp11/detail/mp_fold.hpp>
 #include <boost/mp11/detail/mp_remove_if.hpp>
 #include <boost/mp11/detail/mp_is_list.hpp>
 #include <type_traits>


### PR DESCRIPTION
Crude compile times on my local machine for this testing code:

```cpp
#include <boost/mp11.hpp>
using namespace boost::mp11;

constexpr int N = 16;

using L1 = mp_iota_c<N>;
using L2 = mp_iota_c<N*2>;

template<class T> using Pr = mp_is_set<mp_push_back<L1, T>>;

using R = mp_count_if<L2, Pr>;

static_assert( R::value == N, "" );

int main()
{
}
```
![imagen](https://github.com/user-attachments/assets/bf5d20fa-b577-49db-a71f-3a80d1962efc)

