### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     boost_fetch(boostorg/assert TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/config TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/core TAG develop EXCLUDE_FROM_ALL)
-    boost_fetch(boostorg/static_assert TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/throw_exception TAG develop EXCLUDE_FROM_ALL)
 
     unset(BUILD_TESTING)


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.